### PR TITLE
Explicitly set component's checked value

### DIFF
--- a/src/checkbox/index.js
+++ b/src/checkbox/index.js
@@ -66,7 +66,8 @@ AFRAME.registerComponent('checkbox', {
     // EVENTS
     this.el.addEventListener('click', function() {
       if (this.components.checkbox.data.disabled) { return; }
-      this.setAttribute('checked', !this.components.checkbox.data.checked);
+      this.components.checkbox.data.checked = !this.components.checkbox.data.checked;
+      this.setAttribute('checked', this.components.checkbox.data.checked);
       that.onClick();
     });
     this.el.addEventListener('mousedown', function() {


### PR DESCRIPTION
See issue #7. It looks like, under Firefox, `setAttribute` wasn't immediately setting the component's `checked` property, causing the wrong value to get emitted with the `change` event. This PR sets `checked` explicitly so that it works correctly in all browsers.